### PR TITLE
Make date formatter aware of current locale

### DIFF
--- a/NextStep/Logic/Helpers/NSDateFormatter.swift
+++ b/NextStep/Logic/Helpers/NSDateFormatter.swift
@@ -6,15 +6,17 @@
 
 import Foundation
 
-final class NSDateFormatter {
+/// Convenience for converting dates into user-displayable strings in a unified form.
+extension DateFormatter {
+    
     private static let dateFormatter: DateFormatter = {
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "de_CH")
-        df.setLocalizedDateFormatFromTemplate("dd.MM.yyyy, HH:mm")
-        return df
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+        return dateFormatter
     }()
 
-    static func getDateTimeString(from date: Date) -> String {
+    static func ub_string(from date: Date) -> String {
         dateFormatter.string(from: date)
     }
 }

--- a/NextStep/Screens/Homescreen/Homescreen/Inform/NSInformModuleView.swift
+++ b/NextStep/Screens/Homescreen/Homescreen/Inform/NSInformModuleView.swift
@@ -129,7 +129,7 @@ private class NSInformModuleCTAView: UIView {
             informButton.setTitle("inform_button_title_again".ub_localized, for: .normal)
 
         case let .gemeldet(lastMeldungTime: .some(date)):
-            lastMeldungLabel.text = "inform_last_meldung_text".ub_localized.replacingOccurrences(of: "{date}", with: NSDateFormatter.getDateTimeString(from: date))
+            lastMeldungLabel.text = "inform_last_meldung_text".ub_localized.replacingOccurrences(of: "{date}", with: DateFormatter.ub_string(from: date))
             lastMeldungLabel.isHidden = false
 
             informButton.style = .secondaryOutline
@@ -149,7 +149,7 @@ class NSInformModuleMeldungView: UIView {
     var timestamp: Date? {
         didSet {
             if let t = timestamp {
-                timestampLabel.text = "inform_meldung_time".ub_localized.replacingOccurrences(of: "{date}", with: NSDateFormatter.getDateTimeString(from: t))
+                timestampLabel.text = "inform_meldung_time".ub_localized.replacingOccurrences(of: "{date}", with: DateFormatter.ub_string(from: t))
             } else {
                 timestampLabel.text = nil
             }


### PR DESCRIPTION
Currently the common date formatter had "de_CH" as its locale identifier and a fixed (but localized) date format. The formatter now uses the default locale of the device and also its default date and number format. 

I made sure that the original format stayed the same for Switzerland (or Germany). For these locales, the format is still `dd.MM.yyyy, HH:mm`. 

I also removed the custom class and made this an extension on the default `DateFormatter`.