### PR TITLE
[Added] Dynamic text size support.

### DIFF
--- a/NextStep/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsDetailView.swift
+++ b/NextStep/Screens/Homescreen/BegegnungenDetail/NSBluetoothSettingsDetailView.swift
@@ -75,7 +75,7 @@ class NSBluetoothSettingsDetailView: UIView {
         addSubview(imageView)
 
         imageView.ub_setContentPriorityRequired()
-
+        imageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         imageView.snp.makeConstraints { make in
             make.left.equalToSuperview().inset(NSPadding.medium * 2.0)
             make.top.equalToSuperview().inset(topBottomPadding)

--- a/NextStep/Screens/Homescreen/Homescreen/Base/NSModuleHeaderView.swift
+++ b/NextStep/Screens/Homescreen/Homescreen/Base/NSModuleHeaderView.swift
@@ -36,6 +36,7 @@ class NSModuleHeaderView: UIView {
         addSubview(titleLabel)
         addSubview(rightCaretImageView)
 
+        leftIconImageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         leftIconImageView.ub_setContentPriorityRequired()
         leftIconImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()

--- a/NextStep/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
+++ b/NextStep/Screens/Homescreen/Homescreen/NSHomescreenViewController.swift
@@ -107,7 +107,8 @@ class NSHomescreenViewController: NSViewController {
         let buttonContainer = UIView()
         buttonContainer.addSubview(informButton)
         informButton.snp.makeConstraints { make in
-            make.top.bottom.centerX.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(NSPadding.medium)
         }
         stackScrollView.addArrangedView(buttonContainer)
         stackScrollView.addSpacerView(NSPadding.large)
@@ -120,7 +121,8 @@ class NSHomescreenViewController: NSViewController {
         let debugScreenContainer = UIView()
         debugScreenContainer.addSubview(debugScreenButton)
         debugScreenButton.snp.makeConstraints { make in
-            make.top.bottom.centerX.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(NSPadding.medium)
         }
 
         debugScreenButton.touchUpCallback = { [weak self] in

--- a/NextStep/Screens/Onboarding/NSOnboardingContentViewController.swift
+++ b/NextStep/Screens/Onboarding/NSOnboardingContentViewController.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 class NSOnboardingContentViewController: NSViewController {
-    internal let stackView = UIStackView()
+    internal let stackScrollView = NSStackScrollView(alignment: .center)
 
     private let defaultAnimationOffset: CGFloat = 150
     private let imageAnimationOffset: CGFloat = 400
@@ -21,17 +21,27 @@ class NSOnboardingContentViewController: NSViewController {
 
         view.backgroundColor = .clear
 
-        setupStackView()
+        setupStackScrollView()
     }
 
-    private func setupStackView() {
-        stackView.axis = .vertical
-        stackView.alignment = .center
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        stackScrollView.scrollView.contentInset = UIEdgeInsets(top: NSPadding.large + view.layoutMargins.top, left: 0, bottom: 0, right: 0)
+    }
 
-        view.addSubview(stackView)
-        stackView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(NSPadding.large)
-            make.leading.trailing.equalToSuperview().inset((self.useLessSpacing ? 1.0 : 2.0) * NSPadding.large)
+    private func setupStackScrollView() {
+        stackScrollView.scrollView.alwaysBounceVertical = false
+
+        view.addSubview(stackScrollView)
+        stackScrollView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+        }
+
+        stackScrollView.stackView.snp.remakeConstraints { make in
+            make.top.bottom.centerX.equalToSuperview()
+            make.width.equalToSuperview().inset((self.useLessSpacing ? 1.0 : 2.0) * NSPadding.large)
         }
     }
 
@@ -46,17 +56,17 @@ class NSOnboardingContentViewController: NSViewController {
         view.alpha = 0
 
         if let idx = index {
-            stackView.insertArrangedSubview(wrapperView, at: idx)
+            stackScrollView.addArrangedView(wrapperView, index: idx)
         } else {
-            stackView.addArrangedSubview(wrapperView)
+            stackScrollView.addArrangedView(wrapperView)
         }
         if let s = spacing {
-            stackView.setCustomSpacing(s, after: wrapperView)
+            stackScrollView.stackView.setCustomSpacing(s, after: wrapperView)
         }
     }
 
     func fadeAnimation(fromFactor: CGFloat, toFactor: CGFloat, delay: TimeInterval, completion: ((Bool) -> Void)?) {
-        for (idx, wrapperView) in stackView.arrangedSubviews.enumerated() {
+        for (idx, wrapperView) in stackScrollView.stackView.arrangedSubviews.enumerated() {
             if wrapperView.subviews.count == 0 {
                 print("Error: stack contains subview that were not added with addArrangedView(:,height:)")
                 continue
@@ -67,10 +77,10 @@ class NSOnboardingContentViewController: NSViewController {
             setViewState(view: v, factor: fromFactor)
             UIView.animate(withDuration: 0.5, delay: delay + Double(idx) * 0.05, options: [.beginFromCurrentState], animations: {
                 self.setViewState(view: v, factor: toFactor)
-            }, completion: (idx == stackView.arrangedSubviews.count - 1) ? completion : nil)
+            }, completion: (idx == stackScrollView.stackView.arrangedSubviews.count - 1) ? completion : nil)
         }
 
-        if stackView.arrangedSubviews.count == 0 {
+        if stackScrollView.stackView.arrangedSubviews.count == 0 {
             completion?(true)
         }
     }

--- a/NextStep/Screens/Onboarding/NSOnboardingPermissionsViewController.swift
+++ b/NextStep/Screens/Onboarding/NSOnboardingPermissionsViewController.swift
@@ -12,11 +12,8 @@ class NSOnboardingPermissionsViewController: NSOnboardingContentViewController {
         init(text: String) {
             super.init(frame: .zero)
 
-            snp.makeConstraints { make in
-                make.height.equalTo(44)
-            }
-
             let icon = UIImageView(image: #imageLiteral(resourceName: "ic-check"))
+            icon.adjustsImageSizeForAccessibilityContentSizeCategory = true
             addSubview(icon)
             icon.snp.makeConstraints { make in
                 make.leading.centerY.equalToSuperview()
@@ -27,7 +24,7 @@ class NSOnboardingPermissionsViewController: NSOnboardingContentViewController {
             label.text = text
             addSubview(label)
             label.snp.makeConstraints { make in
-                make.trailing.centerY.equalToSuperview()
+                make.top.trailing.bottom.equalToSuperview()
                 make.leading.equalTo(icon.snp.trailing).offset(NSPadding.medium)
             }
         }

--- a/NextStep/Screens/Onboarding/NSOnboardingStepModel.swift
+++ b/NextStep/Screens/Onboarding/NSOnboardingStepModel.swift
@@ -11,4 +11,5 @@ struct NSOnboardingStepModel {
     let foregroundImage: UIImage
     let title: String
     let text: String
+    let continueButtonTitle: String?
 }

--- a/NextStep/Screens/Onboarding/NSOnboardingStepViewController.swift
+++ b/NextStep/Screens/Onboarding/NSOnboardingStepViewController.swift
@@ -13,6 +13,8 @@ class NSOnboardingStepViewController: NSOnboardingContentViewController {
     private let titleLabel = NSLabel(.subtitle, textColor: .ns_primary)
     private let textLabel = NSLabel(.text)
 
+    let continueButton = NSButton(title: "onboarding_finish_button".ub_localized)
+
     private let model: NSOnboardingStepModel
 
     init(model: NSOnboardingStepModel) {
@@ -32,13 +34,16 @@ class NSOnboardingStepViewController: NSOnboardingContentViewController {
         addArrangedView(foregroundImageView, spacing: (useLessSpacing ? 1.0 : 1.5) * NSPadding.large)
 
         addArrangedView(titleLabel, spacing: (useLessSpacing ? 1.0 : 1.0) * NSPadding.large)
-        addArrangedView(textLabel)
+        addArrangedView(textLabel, spacing: NSPadding.large)
+
+        addArrangedView(continueButton)
 
         foregroundImageView.contentMode = .scaleAspectFit
         foregroundImageView.snp.makeConstraints { make in
             make.height.equalTo(self.useSmallerImages ? 150 : 220)
         }
 
+        headingLabel.textAlignment = .center
         titleLabel.textAlignment = .center
         textLabel.textAlignment = .center
     }
@@ -48,5 +53,7 @@ class NSOnboardingStepViewController: NSOnboardingContentViewController {
         foregroundImageView.image = model.foregroundImage
         titleLabel.text = model.title
         textLabel.text = model.text
+        continueButton.isHidden = model.continueButtonTitle == nil
+        continueButton.setTitle(model.title, for: .normal)
     }
 }

--- a/NextStep/Screens/Onboarding/NSOnboardingViewController.swift
+++ b/NextStep/Screens/Onboarding/NSOnboardingViewController.swift
@@ -13,17 +13,15 @@ class NSOnboardingViewController: NSViewController {
     private let leftSwipeRecognizer = UISwipeGestureRecognizer()
     private let rightSwipeRecognizer = UISwipeGestureRecognizer()
 
-    private let step1VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: " ", foregroundImage: UIImage(named: "onboarding-1")!, title: "onboarding_title_1".ub_localized, text: "onboarding_desc_1".ub_localized))
-    private let step2VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: "Was macht die App:", foregroundImage: UIImage(named: "onboarding-2")!, title: "onboarding_title_2".ub_localized, text: "onboarding_desc_2".ub_localized))
-    private let step3VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: "Was macht die App:", foregroundImage: UIImage(named: "onboarding-3")!, title: "onboarding_title_3".ub_localized, text: "onboarding_desc_3".ub_localized))
+    private let step1VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: " ", foregroundImage: UIImage(named: "onboarding-1")!, title: "onboarding_title_1".ub_localized, text: "onboarding_desc_1".ub_localized, continueButtonTitle: nil))
+    private let step2VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: "Was macht die App:", foregroundImage: UIImage(named: "onboarding-2")!, title: "onboarding_title_2".ub_localized, text: "onboarding_desc_2".ub_localized, continueButtonTitle: nil))
+    private let step3VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: "Was macht die App:", foregroundImage: UIImage(named: "onboarding-3")!, title: "onboarding_title_3".ub_localized, text: "onboarding_desc_3".ub_localized, continueButtonTitle: nil))
     private let step4VC = NSOnboardingPermissionsViewController()
-    private let step5VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: " ", foregroundImage: UIImage(named: "onboarding-3")!, title: "onboarding_title_5".ub_localized, text: "onboarding_desc_5".ub_localized))
+    private let step5VC = NSOnboardingStepViewController(model: NSOnboardingStepModel(heading: " ", foregroundImage: UIImage(named: "onboarding-3")!, title: "onboarding_title_5".ub_localized, text: "onboarding_desc_5".ub_localized, continueButtonTitle: "onboarding_finish_button".ub_localized))
 
     private var stepViewControllers: [NSOnboardingContentViewController] {
         [step1VC, step2VC, step3VC, step4VC, step5VC]
     }
-
-    private let finishButton = NSButton(title: "onboarding_finish_button".ub_localized)
 
     private var currentStep: Int = 0
 
@@ -48,6 +46,10 @@ class NSOnboardingViewController: NSViewController {
             self.present(alert, animated: true, completion: nil)
         }
 
+        step5VC.continueButton.touchUpCallback = { [weak self] in
+            self?.finishAnimation()
+        }
+
         setupSwipeRecognizers()
         addStepViewControllers()
     }
@@ -60,22 +62,6 @@ class NSOnboardingViewController: NSViewController {
 
     fileprivate func setOnboardingStep(_ step: Int, animated: Bool) {
         guard step >= 0, step < stepViewControllers.count else { return }
-        let isLast = step == stepViewControllers.count - 1
-
-        if isLast {
-            finishButton.alpha = 0
-            finishButton.transform = CGAffineTransform(translationX: 300, y: 0)
-            UIView.animate(withDuration: 0.5, delay: 0.5, options: [.beginFromCurrentState], animations: {
-                self.finishButton.alpha = 1
-                self.finishButton.transform = .identity
-            }, completion: nil)
-        } else {
-            UIView.animate(withDuration: 0.5, delay: 0.2, options: [.beginFromCurrentState], animations: {
-                self.finishButton.alpha = 0
-                self.finishButton.transform = CGAffineTransform(translationX: 300, y: 0)
-            }, completion: nil)
-        }
-
         let forward = step >= currentStep
 
         let vcToShow = stepViewControllers[step]
@@ -110,10 +96,6 @@ class NSOnboardingViewController: NSViewController {
 
     private func finishAnimation() {
         let vcToHide = stepViewControllers[currentStep]
-        UIView.animate(withDuration: 0.4, delay: 0, options: [.beginFromCurrentState], animations: {
-            self.finishButton.alpha = 0
-            self.finishButton.transform = CGAffineTransform(translationX: -300, y: 0)
-        }, completion: nil)
         vcToHide.fadeAnimation(fromFactor: 0, toFactor: -1, delay: 0.0) { (_) -> Void in
             User.shared.hasCompletedOnboarding = true
             self.dismiss(animated: true, completion: nil)
@@ -132,14 +114,6 @@ class NSOnboardingViewController: NSViewController {
         pageControl.numberOfPages = stepViewControllers.count
         pageControl.currentPage = 0
         pageControl.isUserInteractionEnabled = false
-
-        view.addSubview(finishButton)
-        finishButton.snp.makeConstraints { make in
-            make.bottom.equalTo(pageControl.snp.top).offset(-NSPadding.small)
-            make.centerX.equalToSuperview()
-        }
-        finishButton.touchUpCallback = finishAnimation
-        finishButton.alpha = 0
     }
 
     private func setupSwipeRecognizers() {
@@ -155,7 +129,7 @@ class NSOnboardingViewController: NSViewController {
     private func addStepViewControllers() {
         for vc in stepViewControllers {
             addChild(vc)
-            view.insertSubview(vc.view, belowSubview: finishButton)
+            view.addSubview(vc.view)
             vc.view.snp.makeConstraints { make in
                 make.top.leading.trailing.equalToSuperview()
                 make.bottom.equalTo(pageControl.snp.top).inset(NSPadding.small)

--- a/NextStep/SharedUI/Base/NSStackScrollView.swift
+++ b/NextStep/SharedUI/Base/NSStackScrollView.swift
@@ -11,7 +11,7 @@ class NSStackScrollView: UIView {
     let stackView = UIStackView()
     let scrollView = UIScrollView()
 
-    init(axis: NSLayoutConstraint.Axis = .vertical, spacing: CGFloat = 0) {
+    init(axis: NSLayoutConstraint.Axis = .vertical, alignment: UIStackView.Alignment = .fill, spacing: CGFloat = 0) {
         super.init(frame: .zero)
 
         switch axis {
@@ -47,6 +47,7 @@ class NSStackScrollView: UIView {
         }
 
         stackView.axis = axis
+        stackView.alignment = alignment
         stackView.spacing = spacing
         stackViewContainer.addSubview(stackView)
 

--- a/NextStep/SharedUI/Controls/NSButton.swift
+++ b/NextStep/SharedUI/Controls/NSButton.swift
@@ -114,4 +114,20 @@ class NSButton: UBButton {
             backgroundColor = isEnabled ? style.backgroundColor : UIColor.black.withAlphaComponent(0.15)
         }
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        titleLabel?.preferredMaxLayoutWidth = titleLabel?.frame.size.width ?? frame.width
+    }
+
+    override var intrinsicContentSize: CGSize {
+        guard var size = titleLabel?.intrinsicContentSize else {
+            return super.intrinsicContentSize
+        }
+
+        size.height += contentEdgeInsets.bottom + contentEdgeInsets.top
+        size.width += contentEdgeInsets.left + contentEdgeInsets.right
+
+        return size
+    }
 }

--- a/NextStep/SharedUI/Helpers/UBButton.swift
+++ b/NextStep/SharedUI/Helpers/UBButton.swift
@@ -55,6 +55,7 @@ class UBButton: UIButton {
         backgroundColor = UIColor.clear
 
         titleLabel?.numberOfLines = 0
+        titleLabel?.adjustsFontForContentSizeCategory = true
         titleLabel?.textAlignment = .center
 
         highlightView.alpha = 0

--- a/NextStep/SharedUI/Helpers/UBLabelType.swift
+++ b/NextStep/SharedUI/Helpers/UBLabelType.swift
@@ -37,6 +37,7 @@ class UBLabel<T: UBLabelType>: UILabel {
         self.textColor = textColor == nil ? self.type.textColor : textColor
         self.textAlignment = textAlignment
         self.numberOfLines = numberOfLines
+        adjustsFontForContentSizeCategory = true
     }
 
     required init?(coder _: NSCoder) {

--- a/NextStep/SharedUI/Style/NSLabelType.swift
+++ b/NextStep/SharedUI/Style/NSLabelType.swift
@@ -16,15 +16,19 @@ public enum NSLabelType: UBLabelType {
     case uppercaseBold
 
     public var font: UIFont {
+        var font: UIFont!
+
         switch self {
-        case .title: return UIFont(name: "Inter-Bold", size: 28.0)!
-        case .subtitle: return UIFont(name: "Inter-Bold", size: 24.0)!
-        case .text: return UIFont(name: "Inter-Regular", size: 16.0)!
-        case .smallBold: return UIFont(name: "Inter-Bold", size: 12.0)!
-        case .textSemiBold: return UIFont(name: "Inter-SemiBold", size: 16.0)!
-        case .button: return UIFont(name: "Inter-Bold", size: 18.0)!
-        case .uppercaseBold: return UIFont(name: "Inter-Bold", size: 16.0)!
+        case .title: font = UIFont(name: "Inter-Bold", size: 28.0)!
+        case .subtitle: font = UIFont(name: "Inter-Bold", size: 24.0)!
+        case .text: font = UIFont(name: "Inter-Regular", size: 16.0)!
+        case .smallBold: font = UIFont(name: "Inter-Bold", size: 12.0)!
+        case .textSemiBold: font = UIFont(name: "Inter-SemiBold", size: 16.0)!
+        case .button: font = UIFont(name: "Inter-Bold", size: 18.0)!
+        case .uppercaseBold: font = UIFont(name: "Inter-Bold", size: 16.0)!
         }
+
+        return scaledMetricFont(font)
     }
 
     public var textColor: UIColor {
@@ -71,6 +75,10 @@ public enum NSLabelType: UBLabelType {
 
     public var lineBreakMode: NSLineBreakMode {
         .byTruncatingTail
+    }
+
+    private func scaledMetricFont(_ font: UIFont) -> UIFont {
+        UIFontMetrics.default.scaledFont(for: font)
     }
 }
 


### PR DESCRIPTION
**Motivation**
Make the app more accessible for people that have the large text option enabled from the accessibility settings on their iPhone.

**Implementation Details**

- Changes are mostly noticeable in the walkthrough screens, where all the subviews have been placed within a NSStackScrollView so users can scroll through the content.

- The option `adjustsImageSizeForAccessibilityContentSizeCategory` and `adjustsFontForContentSizeCategory` have been set for the icons and labels to allow them to readjust to the required accessibility setting.

- See attached screenshot for an example before/after (keep in mind this is only visible if the  corresponding accessibility setting is enabled on the device).

- The behaviour of NSButton has been updated to calculate the intrinsic content size based on the title label, so it can properly fit the content of the label regardless of the font size.

#  **Before:**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-24 at 18 50 56](https://user-images.githubusercontent.com/63914021/80237755-8cc4a700-865d-11ea-841c-5e745b38751d.png)

# **After:**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-24 at 18 51 07](https://user-images.githubusercontent.com/63914021/80237758-8d5d3d80-865d-11ea-86c5-448ac60a31d9.png)



